### PR TITLE
Rabbitmq service setup

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use App\Services\RabbitMQService;
 
 class Kernel extends ConsoleKernel
 {
@@ -24,7 +25,10 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->call(function () {
+            $rabbitMQService = app(RabbitMQService::class);
+            $rabbitMQService->retryPendingMessages();
+        })->everyTenMinutes();
     }
 
     /**

--- a/app/Http/Controllers/RabbitMQController.php
+++ b/app/Http/Controllers/RabbitMQController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\RabbitMQService;
+
+class RabbitMQController extends Controller
+{
+    protected $rabbitMQService;
+
+    public function __construct(RabbitMQService $rabbitMQService)
+    {
+        $this->rabbitMQService = $rabbitMQService;
+    }
+
+    public function publishMessage()
+    {
+        $this->rabbitMQService->publish('queue_name', 'Test message');
+    }
+
+    public function consumeMessages()
+    {
+        $this->rabbitMQService->consume('queue_name', function ($msg) {
+            echo 'Received message: ' . $msg->body;
+        });
+    }
+}

--- a/app/Models/MessagePushStatus.php
+++ b/app/Models/MessagePushStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MessagePushStatus extends Model
+{
+    protected $fillable = ['queue', 'message', 'status'];
+}

--- a/app/Services/RabbitMQService.php
+++ b/app/Services/RabbitMQService.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Services;
+
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Message\AMQPMessage;
+use App\Models\MessagePushStatus;
+use Illuminate\Support\Facades\Log;
+
+class RabbitMQService
+{
+    protected $connection;
+    protected $channel;
+
+    public function __construct()
+    {
+        // Attempt connection
+        $this->connect();
+    }
+
+    private function connect()
+    {
+        // Connect to RabbitMQ
+        try {
+            $host = config('app.rabbitmq_host');
+            $port = config('app.rabbitmq_port');
+            $user = config('app.rabbitmq_user');
+            $password = config('app.rabbitmq_password');
+
+            $this->connection = new AMQPStreamConnection($host, $port, $user, $password);
+            $this->channel = $this->connection->channel();
+        } catch (\Exception $e) {
+            Log::error('RabbitMQ Connection Error: ' . $e->getMessage());
+            $this->connection = null;
+        }
+    }
+
+    public function publish($queue, $message)
+    {
+        // Publish a message to a queue
+        try {
+            if (!$this->connection) {
+                $this->storePendingMessage($queue, $message);
+                return;
+            }
+
+            // Declare the queue
+            $this->channel->queue_declare($queue, false, true, false, false);
+            $msg = new AMQPMessage($message);
+            $this->channel->basic_publish($msg, '', $queue);
+
+            // Save successful message status
+            $this->storeMessageStatus($queue, $message, 'sent');
+        } catch (\Exception $e) {
+            Log::error('RabbitMQ Publish Error: ' . $e->getMessage());
+            $this->storePendingMessage($queue, $message);
+        }
+    }
+
+    private function storePendingMessage($queue, $message)
+    {
+        // Save the message as pending in the database
+        MessagePushStatus::create([
+            'queue' => $queue,
+            'message' => $message,
+            'status' => 'pending',
+        ]);
+    }
+
+    private function storeMessageStatus($queue, $message, $status)
+    {
+        // Update the message status in the database after publishing
+        MessagePushStatus::create([
+            'queue' => $queue,
+            'message' => $message,
+            'status' => $status,
+        ]);
+    }
+
+    public function retryPendingMessages()
+    {
+        // Retry sending pending messages
+        if (!$this->connection) {
+            $this->connect();
+        }
+
+        if ($this->connection) {
+            $pendingMessages = MessagePushStatus::where('status', 'pending')->get();
+
+            foreach ($pendingMessages as $pending) {
+                try {
+                    $this->publish($pending->queue, $pending->message);
+
+                    // If successful, update status to 'sent'
+                    $pending->update(['status' => 'sent']);
+                } catch (\Exception $e) {
+                    Log::error('RabbitMQ Retry Error: ' . $e->getMessage());
+                }
+            }
+        }
+    }
+
+    public function close()
+    {
+        if ($this->channel) {
+            $this->channel->close();
+        }
+        if ($this->connection) {
+            $this->connection->close();
+        }
+    }
+}

--- a/database/migrations/2024_10_24_083034_create_message_push_status_table.php
+++ b/database/migrations/2024_10_24_083034_create_message_push_status_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMessagePushStatusTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('message_push_status', function (Blueprint $table) {
+            $table->id();
+            $table->string('queue');          // The queue name
+            $table->text('message');          // The message payload
+            $table->enum('status', ['pending', 'failed', 'sent'])->default('pending');
+            $table->timestamps();
+        });
+        
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('message_push_status');
+    }
+}


### PR DESCRIPTION
# Setup Rabbit MQ Service
- Create Rabbit MQ Service to store logic for
  - connecting to Rabbit MQ
  - publishing a message
  - consuming a message
  - closing a connection
  This allows the code to be dry and avoid having repeated logic all over the codebase

- Create Rabbit MQ Controller for calling the Rabbit MQ Service
- Create `MessagePushStatus` table and model 
- Create a scheduled task in the kernel that runs every 10 minutes to retry pending messages