### PR TITLE
Updates to RabbitMQ setup

### DIFF
--- a/database/migrations/2024_10_24_083034_create_message_push_statuses_table.php
+++ b/database/migrations/2024_10_24_083034_create_message_push_statuses_table.php
@@ -13,7 +13,7 @@ class CreateMessagePushStatusTable extends Migration
      */
     public function up()
     {
-        Schema::create('message_push_status', function (Blueprint $table) {
+        Schema::create('message_push_statuses', function (Blueprint $table) {
             $table->id();
             $table->string('queue');          // The queue name
             $table->text('message');          // The message payload
@@ -30,6 +30,6 @@ class CreateMessagePushStatusTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('message_push_status');
+        Schema::dropIfExists('message_push_statuses');
     }
 }


### PR DESCRIPTION
- Rename `messagepushstatus` table to `messagepushstatuses` to using plural naming convention