### PR TITLE
Fix datatables header and body alignment

### DIFF
--- a/resources/views/layouts/template_master.blade.php
+++ b/resources/views/layouts/template_master.blade.php
@@ -137,7 +137,6 @@ scratch. This page gets rid of all links and provides the needed markup only.
             $("#example1").DataTable({
                 "responsive": false,
                 "autoWidth": false,
-                "scrollX": true,
                 "lengthChange": true,                
                 "order": [],
                 "lengthMenu": [
@@ -172,7 +171,6 @@ scratch. This page gets rid of all links and provides the needed markup only.
             $("#example2").DataTable({
                 "responsive": false,
                 "autoWidth": false,
-                "scrollX": true,
                 "lengthChange": true,                
                 "order": [],
                 "lengthMenu": [


### PR DESCRIPTION
- Remove scroll-x attribute in datatables settings scrollbar still shows when table content is wider than table width